### PR TITLE
Ensure mocks teardown even when spec fails

### DIFF
--- a/lib/rspec/eventmachine/async_steps.rb
+++ b/lib/rspec/eventmachine/async_steps.rb
@@ -75,11 +75,12 @@ class RSpec::Core::Example
       if @example_group_instance.is_a?(RSpec::EM::AsyncSteps::Scheduler)
         EventMachine.run { synchronous_run(*args, &block) }
         @example_group_instance.verify_mocks_for_rspec
-        @example_group_instance.teardown_mocks_for_rspec
         @example_group_instance.verify_step_queue
       else
         synchronous_run(*args, &block)
       end
+    ensure
+      @example_group_instance.teardown_mocks_for_rspec if @example_group_instance.is_a?(RSpec::EM::AsyncSteps::Scheduler)
     end
   RUBY
 end

--- a/lib/rspec/eventmachine/async_steps.rb
+++ b/lib/rspec/eventmachine/async_steps.rb
@@ -56,7 +56,7 @@ module RSpec::EM
       end
 
       def verify_step_queue
-        unless @__step_queue__&.empty?
+        if @__step_queue__&.size&.positive?
           raise RuntimeError.new("EventMachine terminated before the end of the spec. #{@__step_queue__.size} async steps left to execute: #{@__step_queue__.map(&:first).join(', ')}")
         end
       end

--- a/lib/rspec/eventmachine/async_steps.rb
+++ b/lib/rspec/eventmachine/async_steps.rb
@@ -56,7 +56,7 @@ module RSpec::EM
       end
 
       def verify_step_queue
-        unless @__step_queue__.empty?
+        unless @__step_queue__&.empty?
           raise RuntimeError.new("EventMachine terminated before the end of the spec. #{@__step_queue__.size} async steps left to execute: #{@__step_queue__.map(&:first).join(', ')}")
         end
       end

--- a/lib/rspec/eventmachine/async_steps.rb
+++ b/lib/rspec/eventmachine/async_steps.rb
@@ -54,6 +54,12 @@ module RSpec::EM
       def teardown_mocks_for_rspec
         EventMachine.reactor_running? ? false : super
       end
+
+      def verify_step_queue
+        unless @__step_queue__.empty?
+          raise RuntimeError.new("EventMachine terminated before the end of the spec. #{@__step_queue__.size} async steps left to execute: #{@__step_queue__.map(&:first).join(', ')}")
+        end
+      end
     end
     
   end
@@ -70,6 +76,7 @@ class RSpec::Core::Example
         EventMachine.run { synchronous_run(*args, &block) }
         @example_group_instance.verify_mocks_for_rspec
         @example_group_instance.teardown_mocks_for_rspec
+        @example_group_instance.verify_step_queue
       else
         synchronous_run(*args, &block)
       end

--- a/spec/rspec/eventmachine/async_steps_spec.rb
+++ b/spec/rspec/eventmachine/async_steps_spec.rb
@@ -82,6 +82,13 @@ describe RSpec::EM::AsyncSteps do
       subtract 7
       check_result 11
     end
+
+    it "raises if spec is interrupted" do
+      multiply 6, 3
+      subtract 7
+      check_result 25 # wrong value
+      EM.stop
+    end
   end
 end
 

--- a/spec/rspec/eventmachine/async_steps_spec.rb
+++ b/spec/rspec/eventmachine/async_steps_spec.rb
@@ -89,6 +89,10 @@ describe RSpec::EM::AsyncSteps do
       check_result 25 # wrong value
       EM.stop
     end
+
+    it "do not raise if interrupted with no queue" do
+      EM.stop
+    end
   end
 end
 


### PR DESCRIPTION
In rspec when a spec fails it stops without continuing but it still removes the mocks to prevent from leaking on other specs

https://github.com/rspec/rspec-core/blob/71823ba11ec17a73b25bdc24ebab195494c270dc/lib/rspec/core/example.rb#L521

We should do the same in rspec-em because currently failing specs leak on other specs which is not practical on big CI suites

FTR I couldnt find a way to make a spec on this, since we would need a failing spec, rspec doesn't seem to spec their ensure either but maybe I just wasn't lucky/smart enough to find it in a short time